### PR TITLE
Support rendering Immutable.Map instances

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,6 +47,7 @@ function replaceIterables(obj) {
 			obj[i] = replaceIterables(obj[i]);
 		}
 	} else if (typeof obj.toJS === 'function') {
+		if ('valueSeq' in obj) obj = obj.valueSeq();
 		obj = obj.toJS();
 	}
 	return obj;


### PR DESCRIPTION
Fixes #7. This leverages the fact that all React usage of Immutable assumes only collection/map/set/list/etc values are rendered, and these all implement the `valueSeq()` API:

<img width="336" alt="Screen Shot 2021-05-25 at 4 49 53 PM" src="https://user-images.githubusercontent.com/105127/119566631-5c2bd100-bd79-11eb-914d-cbce72bbdd3e.png">

/cc @mq2thez