### PR TITLE
Update minimum version to 10.26 + re-export APIs for React 18.3 compat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@preact/legacy-compat",
-  "version": "0.1.10",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@preact/legacy-compat",
-      "version": "0.1.10",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "prop-types": "^15.7.2"
@@ -21,11 +21,11 @@
         "jest": "^26.4.2",
         "microbundle": "^0.13.0",
         "npm-merge-driver-install": "^1.1.1",
-        "preact": "^10.12.0",
+        "preact": "^10.26.0",
         "prettier": "^2.1.1"
       },
       "peerDependencies": {
-        "preact": ">=10.12.0 < 11"
+        "preact": ">=10.26.0 < 11"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -15326,9 +15326,9 @@
       "dev": true
     },
     "node_modules/preact": {
-      "version": "10.12.0",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.12.0.tgz",
-      "integrity": "sha512-+w8ix+huD8CNZemheC53IPjMUFk921i02o30u0K6h53spMX41y/QhVDnG/nU2k42/69tvqWmVsgNLIiwRAcmxg==",
+      "version": "10.26.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.26.2.tgz",
+      "integrity": "sha512-0gNmv4qpS9HaN3+40CLBAnKe0ZfyE4ZWo5xKlC1rVrr0ckkEvJvAQqKaHANdFKsGstoxrY4AItZ7kZSGVoVjgg==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -30594,9 +30594,9 @@
       "dev": true
     },
     "preact": {
-      "version": "10.12.0",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.12.0.tgz",
-      "integrity": "sha512-+w8ix+huD8CNZemheC53IPjMUFk921i02o30u0K6h53spMX41y/QhVDnG/nU2k42/69tvqWmVsgNLIiwRAcmxg==",
+      "version": "10.26.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.26.2.tgz",
+      "integrity": "sha512-0gNmv4qpS9HaN3+40CLBAnKe0ZfyE4ZWo5xKlC1rVrr0ckkEvJvAQqKaHANdFKsGstoxrY4AItZ7kZSGVoVjgg==",
       "dev": true
     },
     "prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "dist"
   ],
   "peerDependencies": {
-    "preact": ">=10.12.0 < 11"
+    "preact": ">=10.26.0 < 11"
   },
   "dependencies": {
     "prop-types": "^15.7.2"
@@ -34,7 +34,7 @@
     "jest": "^26.4.2",
     "microbundle": "^0.13.0",
     "npm-merge-driver-install": "^1.1.1",
-    "preact": "^10.12.0",
+    "preact": "^10.26.0",
     "prettier": "^2.1.1"
   },
   "babel": {
@@ -73,7 +73,8 @@
           "allow": [
             "__test__*",
             "unstable_*",
-            "UNSAFE_*"
+            "UNSAFE_*",
+            "__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED"
           ]
         }
       ],

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,9 @@ import {
 	createRef,
 	Fragment,
 	isValidElement,
+	isElement,
+	isFragment,
+	isMemo,
 	findDOMNode,
 	Component,
 	PureComponent,
@@ -39,6 +42,7 @@ import {
 	Suspense,
 	SuspenseList,
 	lazy,
+	__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
 } from 'preact/compat';
 
 import PropTypes from 'prop-types';
@@ -289,6 +293,9 @@ export default {
 	createRef,
 	Fragment,
 	isValidElement,
+	isElement,
+	isFragment,
+	isMemo,
 	findDOMNode,
 	Component,
 	PureComponent,
@@ -300,6 +307,7 @@ export default {
 	Suspense,
 	SuspenseList,
 	lazy,
+	__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
 };
 
 export {
@@ -335,6 +343,9 @@ export {
 	createRef,
 	Fragment,
 	isValidElement,
+	isElement,
+	isFragment,
+	isMemo,
 	findDOMNode,
 	Component,
 	PureComponent,
@@ -346,4 +357,5 @@ export {
 	Suspense,
 	SuspenseList,
 	lazy,
+	__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
 };


### PR DESCRIPTION
Note: this is essentially identical to the last time we did this two years ago, [here](https://github.com/preactjs/legacy-compat/pull/9).